### PR TITLE
Scud Storm launch can no longer be cancelled by accident

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5285,6 +5285,12 @@ Object Chem_GLAScudStorm
     DeathFX       = FX_BuildingDie
   End
 
+  ; Patch104p @bugfix hanfield 06/09/2021 Added LockWeaponCreate to prevent the Scud Storm weapon from switching to primary 
+  ; if a player changes - or forces to change - targets while the Scud Launcher is firing
+  Behavior = LockWeaponCreate ModuleTag_ScudBugFix
+    SlotToLock = SECONDARY 
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 71.0
   GeometryMinorRadius = 67.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -4608,6 +4608,12 @@ Object Demo_GLAScudStorm
     DeathFX       = FX_BuildingDie
   End
 
+  ; Patch104p @bugfix hanfield 06/09/2021 Added LockWeaponCreate to prevent the Scud Storm weapon from switching to primary 
+  ; if a player changes - or forces to change - targets while the Scud Launcher is firing
+  Behavior = LockWeaponCreate ModuleTag_ScudBugFix
+    SlotToLock = SECONDARY 
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 71.0
   GeometryMinorRadius = 67.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -13341,6 +13341,12 @@ Object GLAScudStorm
     DeathFX       = FX_BuildingDie
   End
 
+  ; Patch104p @bugfix hanfield 06/09/2021 Added LockWeaponCreate to prevent the Scud Storm weapon from switching to primary 
+  ; if a player changes - or forces to change - targets while the Scud Launcher is firing
+  Behavior = LockWeaponCreate ModuleTag_ScudBugFix
+    SlotToLock = SECONDARY 
+  End
+  
   Geometry            = BOX
   GeometryMajorRadius = 71.0
   GeometryMinorRadius = 67.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -5323,6 +5323,11 @@ Object Slth_GLAScudStorm
     DeathFX       = FX_BuildingDie
   End
 
+  ; Patch104p @bugfix hanfield 06/09/2021 Added LockWeaponCreate to prevent the Scud Storm weapon from switching to primary 
+  ; if a player changes - or forces to change - targets while the Scud Launcher is firing
+  Behavior = LockWeaponCreate ModuleTag_ScudBugFix
+    SlotToLock = SECONDARY 
+  End
 ;  Behavior = GrantUpgradeCreate ModuleTag_900
 ;    UpgradeToGrant = Upgrade_GLACamoNetting
 ;  End


### PR DESCRIPTION
Scud Storm, if given a target or ordered to force fire while launching, would try to swap to a non-existent primary weapon and thereby stop the launch. This commit fixes that.