### PR TITLE
Terrorists should no longer crash the game under certain conditions

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1423,8 +1423,10 @@ Object GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
+; Patch104p @bugfix hanfield 05/09/2021 Added DESTROYED status as a requirement for a death without fireworks. This one is used inside of Technicals and Battle Buses.
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED
+    DeathTypes          = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    RequiredStatus      = DESTROYED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -1434,11 +1436,29 @@ Object GLAInfantryTerrorist
     FlingPitch          = 60
     FlingPitchVariance  = 10
   End
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
-    DeathWeapon   = SuicideDynamitePack
-    StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+
+; Patch104p @bugfix hanfield 05/09/2021 Added a new death module for when Terrorists are not inside a container. It works as normal.
+  Behavior = SlowDeathBehavior ModuleTag_Death03Contained
+    DeathTypes          = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    ExemptStatus        = DESTROYED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_TerroristExplode
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+    Weapon = INITIAL SuicideDynamitePack
   End
+
+; Patch104p @bugfix hanfield 05/09/2021 Commented out the old death weapon.
+  ;Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
+  ;  DeathWeapon   = SuicideDynamitePack
+  ;  StartsActive  = Yes                      ; turned on by upgrade
+  ;  DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+  ;  ExemptStatus = DESTROYED
+  ;End
 ; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_14

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -4851,6 +4851,7 @@ Object GLAVehicleTechnicalChassisOne
     AllowInsideKindOf   = INFANTRY
     DamagePercentToUnits = 10%
     GoAggressiveOnExit = Yes ; AI Will tell people to set their mood to Aggressive on exiting
+    DestroyRidersWhoAreNotFreeToExit = Yes   ; Patch104p @bugfix hanfield 05/09/2021 Added this parameter to make contained objects be flagged with DESTROYED status.
    End
 
   Behavior = WeaponBonusUpgrade ModuleTag_17 ; Not a full weapon set switch, just a number tweak reflected in a weapon.
@@ -6368,6 +6369,7 @@ Object GLAVehicleBattleBus
     WeaponBonusPassedToPassengers = Yes
     DelayExitInAir = Yes
     ArmedRidersUpgradeMyWeaponSet = Yes
+    DestroyRidersWhoAreNotFreeToExit = Yes ; Patch104p @bugfix hanfield 05/09/2021 Added this parameter to make contained objects be flagged with DESTROYED status.
   End
 
 ; Module 11 cut.


### PR DESCRIPTION
Terrorists crashed the game in two scenarios:
1. When Terrorists are inside of a Battle Bus and have less than 50% health, the game would crash as soon as the Battle Bus turned into a bunker.
2. When Terrorists are inside of a Technical, the game would crash whenever they get hit by a neutron shell.
This commit fixes the crash in both instances.